### PR TITLE
Harden cron auth, CF Access validation, admin login rate limits, and Notion env vars

### DIFF
--- a/env.example.txt
+++ b/env.example.txt
@@ -2,12 +2,11 @@
 # Note: These are only needed if you want to sync data to Notion for reports
 
 # Notion API Configuration (Optional - for syncing to Notion)
-VITE_NOTION_API_KEY=secret_your_integration_token_here
+NOTION_API_KEY=secret_your_integration_token_here
 
 # Notion Database IDs (for syncing different branches to different databases)
-VITE_NOTION_DB_1=your_database_id_1
-VITE_NOTION_DB_2=your_database_id_2
-VITE_NOTION_DB_3=your_database_id_3
-VITE_NOTION_DB_4=your_database_id_4
-VITE_NOTION_DB_5=your_database_id_5
-
+NOTION_DB_1=your_database_id_1
+NOTION_DB_2=your_database_id_2
+NOTION_DB_3=your_database_id_3
+NOTION_DB_4=your_database_id_4
+NOTION_DB_5=your_database_id_5

--- a/functions/api/backup.js
+++ b/functions/api/backup.js
@@ -5,15 +5,13 @@
  * Protected endpoint - requires ADMIN_PASSWORD Bearer token
  */
 
-import { isAuthenticated, unauthorizedResponse } from '../utils/auth.js'
+import { isAuthenticated, unauthorizedResponse, isAuthorizedCronRequest } from '../utils/auth.js'
 
 export async function onRequestPost(context) {
   const { request, env } = context
   
-  // Check authentication (skip for cron triggers)
-  // Cron triggers don't include Authorization header, so we allow them through
-  // Manual triggers require authentication
-  const isCronTrigger = request.headers.get('CF-Scheduled') !== null
+  // Check authentication (allow authorized cron triggers)
+  const isCronTrigger = isAuthorizedCronRequest(request, env)
   if (!isCronTrigger) {
     const authenticated = await isAuthenticated(request, env)
     if (!authenticated) {
@@ -214,4 +212,3 @@ export async function listBackups(env) {
     return []
   }
 }
-

--- a/functions/api/dashboard.js
+++ b/functions/api/dashboard.js
@@ -147,6 +147,9 @@ export async function onRequestGet(context) {
       name: error.name
     })
     
+    const envConfig = getEnvironmentConfig(request, env)
+    const exposeDetails = envConfig.isSandbox
+
     // Provide more helpful error messages for common issues
     let errorMessage = 'An error occurred while processing your request. Please try again later.'
     let errorType = 'Internal server error'
@@ -162,8 +165,8 @@ export async function onRequestGet(context) {
     } else if (errorMsg.includes('syntax error')) {
       errorType = 'Database Query Error'
       errorMessage = 'Database query syntax error. Please check the server logs for details.'
-    } else if (errorMsg.length > 0 && errorMsg.length < 200) {
-      // Include the error message if it's short and doesn't contain sensitive info
+    } else if (exposeDetails && errorMsg.length > 0 && errorMsg.length < 200) {
+      // Include the error message only in sandbox/preview
       errorMessage = errorMsg
     }
     
@@ -460,4 +463,3 @@ async function generateReport(db, field1, field2) {
     total: result.results?.reduce((sum, row) => sum + (row.count || 0), 0) || 0,
   }
 }
-

--- a/functions/api/submit.js
+++ b/functions/api/submit.js
@@ -590,9 +590,12 @@ export async function onRequestPost(context) {
       name: error.name
     })
     
+    const envConfig = getEnvironmentConfig(request, env)
+    const exposeDetails = envConfig.isSandbox
+
     // Provide more helpful error messages for common issues
     let errorMessage = 'Internal server error'
-    let errorDetails = error.message || 'Unknown error'
+    let errorDetails = 'An unexpected error occurred. Please try again later.'
     
     // Check for database constraint violations
     if (error.message && (
@@ -608,8 +611,8 @@ export async function onRequestPost(context) {
     } else if (error.message && error.message.includes('no such column')) {
       errorMessage = 'Database schema error'
       errorDetails = 'Database column not found. Please run migrations to update the schema.'
-    } else if (error.message && error.message.length < 200) {
-      // Include the error message if it's short and doesn't contain sensitive info
+    } else if (exposeDetails && error.message && error.message.length < 200) {
+      // Include the error message only in sandbox/preview
       errorDetails = error.message
     }
     

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -110,12 +110,12 @@ ENVIRONMENT = "sandbox"
 # Cron triggers bypass authentication automatically
 
 # Optional: Notion integration (set via Cloudflare Dashboard secrets if using Notion)
-# VITE_NOTION_API_KEY = "" # Set via: wrangler secret put VITE_NOTION_API_KEY
-# VITE_NOTION_DB_1 = ""
-# VITE_NOTION_DB_2 = ""
-# VITE_NOTION_DB_3 = ""
-# VITE_NOTION_DB_4 = ""
-# VITE_NOTION_DB_5 = ""
+# NOTION_API_KEY = "" # Set via: wrangler secret put NOTION_API_KEY
+# NOTION_DB_1 = ""
+# NOTION_DB_2 = ""
+# NOTION_DB_3 = ""
+# NOTION_DB_4 = ""
+# NOTION_DB_5 = ""
 
 # Note: Cron triggers for Pages Functions
 # Cron triggers MUST be configured in Cloudflare Dashboard (they cannot be set via wrangler.toml)
@@ -136,4 +136,3 @@ ENVIRONMENT = "sandbox"
 #   npx wrangler pages secret put BACKUP_SECRET --project-name survey
 #   npx wrangler pages secret put SANITIZE_SECRET --project-name survey
 #   npx wrangler pages secret put ADMIN_PASSWORD --project-name survey
-


### PR DESCRIPTION
### Motivation
- Ensure cron-triggered endpoints are only executed when a secret is provided and validated to avoid unauthorized scheduled operations.
- Tighten Cloudflare Access JWT validation to reject expired or mismatched tokens and optionally enforce audience and issuer claims.
- Reduce attack surface for admin authentication by rate limiting login attempts and avoid leaking sensitive error details in production.
- Keep Notion integration credentials server-side by moving from client-prefixed `VITE_` vars to server-only `NOTION_` variables.

### Description
- Added `isAuthorizedCronRequest` and new cron secret header handling (`CF-Scheduled` / `X-Cron-Secret`) in `functions/utils/auth.js` and replaced raw header checks in `functions/api/backup.js`, `functions/api/sanitize.js`, and `functions/api/sync-to-notion.js` to allow only authorized cron triggers.
- Hardened Cloudflare Access JWT parsing in `functions/utils/auth.js` by validating `exp` and, when configured, `aud` via `CF_ACCESS_AUD` and `iss` via `CF_ACCESS_ISS`, and returned normalized `userInfo` on success.
- Implemented admin login rate limiting by importing `checkRateLimit` and `getClientIP` from `utils/sanitization.js` and returning `429` with `Retry-After` when exceeded in `functions/api/admin.js`.
- Reduced error detail exposure in `functions/api/submit.js` and `functions/api/dashboard.js` by only revealing short error messages when `getEnvironmentConfig(request, env).isSandbox` is true, and migrated Notion env vars from `VITE_NOTION_*` to `NOTION_*` across `functions/api/sync-to-notion.js`, `env.example.txt`, and `wrangler.toml`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f488034e48333aa92bed4a27950ab)